### PR TITLE
[packaging] Add bluetooth related patches.

### DIFF
--- a/rpm/1001-combine-Fix-crash-in-output-freeing.patch
+++ b/rpm/1001-combine-Fix-crash-in-output-freeing.patch
@@ -1,0 +1,33 @@
+From b9b3cd13c15e54c3aeda1c72082be7b7c58ad4c3 Mon Sep 17 00:00:00 2001
+From: Tanu Kaskinen <tanu.kaskinen@linux.intel.com>
+Date: Tue, 18 Jun 2013 21:21:08 +0300
+Subject: [PATCH] combine: Fix crash in output freeing
+
+The outputs are removed from the idxset before output_free() is
+called. Trying to remove them again in output_free(), and asserting
+that it should succeed caused crashing whenever outputs were freed.
+
+This bug was introduced in commit
+061878b5a47ed9aa05d12430b039874b63c29a84.
+
+BugLink: https://bugs.freedesktop.org/show_bug.cgi?id=65901
+---
+ src/modules/module-combine-sink.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/src/modules/module-combine-sink.c b/src/modules/module-combine-sink.c
+index 7d660f0..faf65c2 100644
+--- a/src/modules/module-combine-sink.c
++++ b/src/modules/module-combine-sink.c
+@@ -923,8 +923,6 @@ static void output_free(struct output *o) {
+     pa_assert(o);
+ 
+     output_disable(o);
+-
+-    pa_assert_se(pa_idxset_remove_by_data(o->userdata->outputs, o, NULL));
+     update_description(o->userdata);
+ 
+     if (o->inq_rtpoll_item_read)
+-- 
+1.8.4.1
+

--- a/rpm/2001-build-Install-pulsecore-headers.patch
+++ b/rpm/2001-build-Install-pulsecore-headers.patch
@@ -1,7 +1,7 @@
-From bdc822bd2395bb87ac346c4be831e157eb981912 Mon Sep 17 00:00:00 2001
+From 8939abc6f23dcb6c646b50db99c3fb5b4b494005 Mon Sep 17 00:00:00 2001
 From: Tanu Kaskinen <tanu.kaskinen@jollamobile.com>
 Date: Wed, 5 Sep 2012 12:23:59 +0300
-Subject: [PATCH 1/7] build: Install pulsecore headers.
+Subject: [PATCH 2001/2010] build: Install pulsecore headers.
 
 This is for building out-of-tree modules. Upstream doesn't want to
 support out-of-tree modules, so this patch is not upstreamable.
@@ -194,5 +194,5 @@ index a621a30..88db31c 100644
  ###################################
  
 -- 
-1.8.4
+1.8.5.2
 

--- a/rpm/2002-Use-etc-boardname-to-load-a-hardware-specific-config.patch
+++ b/rpm/2002-Use-etc-boardname-to-load-a-hardware-specific-config.patch
@@ -1,7 +1,7 @@
-From 521c96781eb2de517ae5bdfb1601d06c0b6c1ffc Mon Sep 17 00:00:00 2001
+From 4e91d9b466af068d944dbeecbb2813618af19e52 Mon Sep 17 00:00:00 2001
 From: Tanu Kaskinen <tanu.kaskinen@jollamobile.com>
 Date: Wed, 10 Oct 2012 11:07:48 +0300
-Subject: [PATCH 2/7] Use /etc/boardname to load a hardware specific
+Subject: [PATCH 2002/2010] Use /etc/boardname to load a hardware specific
  configuration file.
 
 I think it would be better to add support for /etc/boardname directly
@@ -104,5 +104,5 @@ index 17753b0..85c8890 100644
  
  ; cookie-file =
 -- 
-1.8.4
+1.8.5.2
 

--- a/rpm/2003-daemon-Disable-automatic-shutdown-by-default.patch
+++ b/rpm/2003-daemon-Disable-automatic-shutdown-by-default.patch
@@ -1,7 +1,7 @@
-From 4ec3e5a99b7be15b6724d9fc59fb3f8133afe3e8 Mon Sep 17 00:00:00 2001
+From 5b6b33efa72f1b88dcd7c9c3254821a9eaf55c65 Mon Sep 17 00:00:00 2001
 From: Tanu Kaskinen <tanu.kaskinen@jollamobile.com>
 Date: Wed, 10 Oct 2012 11:17:04 +0300
-Subject: [PATCH 3/7] daemon: Disable automatic shutdown by default.
+Subject: [PATCH 2003/2010] daemon: Disable automatic shutdown by default.
 
 Mer (or rather Nemo) specific patch, not upstreamable.
 ---
@@ -31,5 +31,5 @@ index dff97ae..dcf9020 100644
  
  ; dl-search-path = (depends on architecture)
 -- 
-1.8.4
+1.8.5.2
 

--- a/rpm/2004-daemon-Set-default-resampler-to-speex-fixed-2.patch
+++ b/rpm/2004-daemon-Set-default-resampler-to-speex-fixed-2.patch
@@ -1,8 +1,8 @@
-From e07582a3509c51f4e0b40c31d89cd80f805b410d Mon Sep 17 00:00:00 2001
+From 38b33912a13b1e3cbf643b524f45564d1cfc3305 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Juho=20H=C3=A4m=C3=A4l=C3=A4inen?=
  <juho.hamalainen@tieto.com>
 Date: Fri, 20 Sep 2013 14:02:40 +0300
-Subject: [PATCH 4/7] daemon: Set default resampler to speex-fixed-2.
+Subject: [PATCH 2004/2010] daemon: Set default resampler to speex-fixed-2.
 
 ---
  src/daemon/daemon.conf.in | 17 +++++++++++++++++
@@ -37,5 +37,5 @@ index dcf9020..731dab2 100644
  ; enable-remixing = yes
  ; enable-lfe-remixing = no
 -- 
-1.8.4
+1.8.5.2
 

--- a/rpm/2005-bluetooth-Allow-leaving-transport-running-while-sink.patch
+++ b/rpm/2005-bluetooth-Allow-leaving-transport-running-while-sink.patch
@@ -1,9 +1,9 @@
-From 353961c99098658944d1720d3bb115932d203d20 Mon Sep 17 00:00:00 2001
+From 7016cdfc8124bd88b8f0353d723ecb5ecab7d005 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Juho=20H=C3=A4m=C3=A4l=C3=A4inen?=
  <juho.hamalainen@tieto.com>
 Date: Wed, 18 Sep 2013 14:13:47 +0300
-Subject: [PATCH 5/7] bluetooth: Allow leaving transport running while sink and
- source are suspended.
+Subject: [PATCH 2005/2010] bluetooth: Allow leaving transport running while
+ sink and source are suspended.
 
 There are some cases where keeping the SCO transport running even when
 SCO sink and source are suspended is needed. This patch allows keeping
@@ -139,5 +139,5 @@ index fd6739d..53a22de 100644
          restore_sco_volume_callbacks(u);
  
 -- 
-1.8.4
+1.8.5.2
 

--- a/rpm/2006-client-Disable-client-autospawn-by-default.patch
+++ b/rpm/2006-client-Disable-client-autospawn-by-default.patch
@@ -1,8 +1,8 @@
-From b65ad737c66d50fbe6d699a4215ff3eca293f8a2 Mon Sep 17 00:00:00 2001
+From 245d1ac4b61bc6e59ec77b832cdd259668803337 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Juho=20H=C3=A4m=C3=A4l=C3=A4inen?=
  <juho.hamalainen@tieto.com>
 Date: Fri, 4 Oct 2013 12:41:15 +0300
-Subject: [PATCH 6/7] client: Disable client autospawn by default.
+Subject: [PATCH 2006/2010] client: Disable client autospawn by default.
 
 Not upstreamable.
 ---
@@ -29,5 +29,5 @@ index 85c8890..530c6f0 100644
  ; extra-arguments = --log-target=syslog
  
 -- 
-1.8.4
+1.8.5.2
 

--- a/rpm/2007-bluetooth-device-Do-not-lose-transport-pointer-after.patch
+++ b/rpm/2007-bluetooth-device-Do-not-lose-transport-pointer-after.patch
@@ -1,9 +1,9 @@
-From a8d624936c48a55799bc719b2f4fd9b25fe64091 Mon Sep 17 00:00:00 2001
+From 3f468de85ecfd773f5fc8479e630826a4e133676 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Juho=20H=C3=A4m=C3=A4l=C3=A4inen?=
  <juho.hamalainen@tieto.com>
 Date: Wed, 16 Oct 2013 10:54:20 +0300
-Subject: [PATCH 7/7] [bluetooth] Do not lose transport pointer after getting
- it.
+Subject: [PATCH 2007/2010] bluetooth-device: Do not lose transport pointer
+ after getting it.
 
 When u->transport has valid pointer, it seems most code assumes it to
 stay non-NULL. When profile switch fails, stop_thread() clears the
@@ -28,5 +28,5 @@ index 53a22de..04320d3 100644
  
      if (u->sink) {
 -- 
-1.8.4
+1.8.5.2
 

--- a/rpm/2008-bluetooth-device-Default-to-using-A2DP-profile-initi.patch
+++ b/rpm/2008-bluetooth-device-Default-to-using-A2DP-profile-initi.patch
@@ -1,0 +1,101 @@
+From e25d3a1de73510ddc8e60e355e78d4bb7100c9fa Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Juho=20H=C3=A4m=C3=A4l=C3=A4inen?=
+ <juho.hamalainen@tieto.com>
+Date: Wed, 11 Dec 2013 18:27:07 +0200
+Subject: [PATCH 2008/2010] bluetooth-device: Default to using A2DP profile
+ initially.
+
+By default have A2DP profiles with higher priority than HFP profiles,
+since usually when A2DP+HFP-capable device is connected, it's meant for
+A2DP streaming. This behavior can be dynamically overridden by setting
+property bluetooth.prefer.hsp as true to SCO sink. When this property is
+found in SCO sink upon bluetooth-device startup, HFP profiles have
+higher priority than A2DP to select HFP initially.
+---
+ src/modules/bluetooth/module-bluetooth-device.c | 28 +++++++++++++++++++++----
+ 1 file changed, 24 insertions(+), 4 deletions(-)
+
+diff --git a/src/modules/bluetooth/module-bluetooth-device.c b/src/modules/bluetooth/module-bluetooth-device.c
+index 04320d3..264feec 100644
+--- a/src/modules/bluetooth/module-bluetooth-device.c
++++ b/src/modules/bluetooth/module-bluetooth-device.c
+@@ -208,6 +208,8 @@ enum {
+ 
+ #define USE_SCO_OVER_PCM(u) (u->profile == PROFILE_HSP && (u->hsp.sco_sink && u->hsp.sco_source))
+ 
++#define BLUETOOTH_PREFER_HSP "bluetooth.prefer.hsp"
++
+ static int init_profile(struct userdata *u);
+ 
+ /* from IO thread */
+@@ -2222,6 +2224,22 @@ static void create_card_ports(struct userdata *u, pa_hashmap *ports) {
+     port->available = get_port_availability(u, PA_DIRECTION_INPUT);
+ }
+ 
++static int check_prefer_hsp(struct userdata *u) {
++    const char *tmp;
++    int prefer_hsp = 0;
++
++    pa_assert(u);
++
++    if (u->hsp.sco_sink) {
++        if ((tmp = pa_proplist_gets(u->hsp.sco_sink->proplist, BLUETOOTH_PREFER_HSP))) {
++            if (pa_streq(tmp, "true"))
++                prefer_hsp = 20;
++        }
++    }
++
++    return prefer_hsp;
++}
++
+ /* Run from main thread */
+ static pa_card_profile *create_card_profile(struct userdata *u, const char *uuid, pa_hashmap *ports) {
+     pa_device_port *input_port, *output_port;
+@@ -2235,7 +2253,7 @@ static pa_card_profile *create_card_profile(struct userdata *u, const char *uuid
+ 
+     if (pa_streq(uuid, A2DP_SINK_UUID)) {
+         p = pa_card_profile_new("a2dp", _("High Fidelity Playback (A2DP)"), sizeof(enum profile));
+-        p->priority = 10;
++        p->priority = 20;
+         p->n_sinks = 1;
+         p->n_sources = 0;
+         p->max_sink_channels = 2;
+@@ -2246,7 +2264,7 @@ static pa_card_profile *create_card_profile(struct userdata *u, const char *uuid
+         *d = PROFILE_A2DP;
+     } else if (pa_streq(uuid, A2DP_SOURCE_UUID)) {
+         p = pa_card_profile_new("a2dp_source", _("High Fidelity Capture (A2DP)"), sizeof(enum profile));
+-        p->priority = 10;
++        p->priority = 20;
+         p->n_sinks = 0;
+         p->n_sources = 1;
+         p->max_sink_channels = 0;
+@@ -2257,7 +2275,7 @@ static pa_card_profile *create_card_profile(struct userdata *u, const char *uuid
+         *d = PROFILE_A2DP_SOURCE;
+     } else if (pa_streq(uuid, HSP_HS_UUID) || pa_streq(uuid, HFP_HS_UUID)) {
+         p = pa_card_profile_new("hsp", _("Telephony Duplex (HSP/HFP)"), sizeof(enum profile));
+-        p->priority = 20;
++        p->priority = 10 + check_prefer_hsp(u);
+         p->n_sinks = 1;
+         p->n_sources = 1;
+         p->max_sink_channels = 1;
+@@ -2269,7 +2287,7 @@ static pa_card_profile *create_card_profile(struct userdata *u, const char *uuid
+         *d = PROFILE_HSP;
+     } else if (pa_streq(uuid, HFP_AG_UUID)) {
+         p = pa_card_profile_new("hfgw", _("Handsfree Gateway"), sizeof(enum profile));
+-        p->priority = 20;
++        p->priority = 10 + check_prefer_hsp(u);
+         p->n_sinks = 1;
+         p->n_sources = 1;
+         p->max_sink_channels = 1;
+@@ -2377,6 +2395,8 @@ static int add_card(struct userdata *u) {
+ 
+     d = PA_CARD_PROFILE_DATA(u->card->active_profile);
+ 
++    pa_log_debug("Select initial profile (%s)", *d == PROFILE_OFF ? "off" : pa_bt_profile_to_string(*d));
++
+     if (*d != PROFILE_OFF && (!device->transports[*d] ||
+                               device->transports[*d]->state == PA_BLUETOOTH_TRANSPORT_STATE_DISCONNECTED)) {
+         pa_log_warn("Default profile not connected, selecting off profile");
+-- 
+1.8.5.2
+

--- a/rpm/2009-module-rescue-streams-Add-parameters-to-define-targe.patch
+++ b/rpm/2009-module-rescue-streams-Add-parameters-to-define-targe.patch
@@ -1,0 +1,211 @@
+From a3f320e26e7d7f47f8a016566ccc5c39fc1940be Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Juho=20H=C3=A4m=C3=A4l=C3=A4inen?=
+ <juho.hamalainen@tieto.com>
+Date: Fri, 20 Dec 2013 18:43:28 +0200
+Subject: [PATCH 2009/2010] module-rescue-streams: Add parameters to define
+ targets for rescued streams.
+
+---
+ src/modules/module-rescue-streams.c | 63 ++++++++++++++++++++++++++++++-------
+ 1 file changed, 52 insertions(+), 11 deletions(-)
+
+diff --git a/src/modules/module-rescue-streams.c b/src/modules/module-rescue-streams.c
+index 8b35809..0cc767d 100644
+--- a/src/modules/module-rescue-streams.c
++++ b/src/modules/module-rescue-streams.c
+@@ -39,12 +39,20 @@ PA_MODULE_AUTHOR("Lennart Poettering");
+ PA_MODULE_DESCRIPTION("When a sink/source is removed, try to move their streams to the default sink/source");
+ PA_MODULE_VERSION(PACKAGE_VERSION);
+ PA_MODULE_LOAD_ONCE(TRUE);
++PA_MODULE_USAGE(
++        "sink_name=<name for sink that is tried first when rescuing sinks."
++        "source_name=<name for source that is tried first when rescuing sources.");
+ 
+ static const char* const valid_modargs[] = {
++    "sink_name",
++    "source_name",
+     NULL,
+ };
+ 
+ struct userdata {
++    char *sink_name;
++    char *source_name;
++
+     pa_hook_slot
+         *sink_unlink_slot,
+         *source_unlink_slot,
+@@ -52,13 +60,21 @@ struct userdata {
+         *source_output_move_fail_slot;
+ };
+ 
+-static pa_sink* find_evacuation_sink(pa_core *c, pa_sink_input *i, pa_sink *skip) {
++static pa_sink* find_evacuation_sink(struct userdata *u, pa_core *c, pa_sink_input *i, pa_sink *skip) {
+     pa_sink *target, *def;
+     uint32_t idx;
+ 
++    pa_assert(u);
+     pa_assert(c);
+     pa_assert(i);
+ 
++    if (u->sink_name) {
++        if ((target = pa_namereg_get(c, u->sink_name, PA_NAMEREG_SINK))) {
++            if (target != skip)
++                return target;
++        }
++    }
++
+     def = pa_namereg_get_default_sink(c);
+ 
+     if (def && def != skip && pa_sink_input_may_move_to(i, def))
+@@ -82,12 +98,13 @@ static pa_sink* find_evacuation_sink(pa_core *c, pa_sink_input *i, pa_sink *skip
+     return NULL;
+ }
+ 
+-static pa_hook_result_t sink_unlink_hook_callback(pa_core *c, pa_sink *sink, void* userdata) {
++static pa_hook_result_t sink_unlink_hook_callback(pa_core *c, pa_sink *sink, struct userdata *u) {
+     pa_sink_input *i;
+     uint32_t idx;
+ 
+     pa_assert(c);
+     pa_assert(sink);
++    pa_assert(u);
+ 
+     /* There's no point in doing anything if the core is shut down anyway */
+     if (c->state == PA_CORE_SHUTDOWN)
+@@ -101,7 +118,7 @@ static pa_hook_result_t sink_unlink_hook_callback(pa_core *c, pa_sink *sink, voi
+     PA_IDXSET_FOREACH(i, sink->inputs, idx) {
+         pa_sink *target;
+ 
+-        if (!(target = find_evacuation_sink(c, i, sink)))
++        if (!(target = find_evacuation_sink(u, c, i, sink)))
+             continue;
+ 
+         if (pa_sink_input_move_to(i, target, FALSE) < 0)
+@@ -115,17 +132,18 @@ static pa_hook_result_t sink_unlink_hook_callback(pa_core *c, pa_sink *sink, voi
+     return PA_HOOK_OK;
+ }
+ 
+-static pa_hook_result_t sink_input_move_fail_hook_callback(pa_core *c, pa_sink_input *i, void *userdata) {
++static pa_hook_result_t sink_input_move_fail_hook_callback(pa_core *c, pa_sink_input *i, struct userdata *u) {
+     pa_sink *target;
+ 
+     pa_assert(c);
+     pa_assert(i);
++    pa_assert(u);
+ 
+     /* There's no point in doing anything if the core is shut down anyway */
+     if (c->state == PA_CORE_SHUTDOWN)
+         return PA_HOOK_OK;
+ 
+-    if (!(target = find_evacuation_sink(c, i, NULL)))
++    if (!(target = find_evacuation_sink(u, c, i, NULL)))
+         return PA_HOOK_OK;
+ 
+     if (pa_sink_input_finish_move(i, target, FALSE) < 0) {
+@@ -140,13 +158,22 @@ static pa_hook_result_t sink_input_move_fail_hook_callback(pa_core *c, pa_sink_i
+     }
+ }
+ 
+-static pa_source* find_evacuation_source(pa_core *c, pa_source_output *o, pa_source *skip) {
++static pa_source* find_evacuation_source(struct userdata *u, pa_core *c, pa_source_output *o, pa_source *skip) {
+     pa_source *target, *def;
+     uint32_t idx;
+ 
++    pa_assert(u);
+     pa_assert(c);
+     pa_assert(o);
+ 
++    if (u->source_name) {
++        if ((target = pa_namereg_get(c, u->source_name, PA_NAMEREG_SOURCE))) {
++            if (target != skip)
++                return target;
++        }
++    }
++
++
+     def = pa_namereg_get_default_source(c);
+ 
+     if (def && def != skip && pa_source_output_may_move_to(o, def))
+@@ -173,12 +200,13 @@ static pa_source* find_evacuation_source(pa_core *c, pa_source_output *o, pa_sou
+     return NULL;
+ }
+ 
+-static pa_hook_result_t source_unlink_hook_callback(pa_core *c, pa_source *source, void* userdata) {
++static pa_hook_result_t source_unlink_hook_callback(pa_core *c, pa_source *source, struct userdata *u) {
+     pa_source_output *o;
+     uint32_t idx;
+ 
+     pa_assert(c);
+     pa_assert(source);
++    pa_assert(u);
+ 
+     /* There's no point in doing anything if the core is shut down anyway */
+     if (c->state == PA_CORE_SHUTDOWN)
+@@ -192,7 +220,7 @@ static pa_hook_result_t source_unlink_hook_callback(pa_core *c, pa_source *sourc
+     PA_IDXSET_FOREACH(o, source->outputs, idx) {
+         pa_source *target;
+ 
+-        if (!(target = find_evacuation_source(c, o, source)))
++        if (!(target = find_evacuation_source(u, c, o, source)))
+             continue;
+ 
+         if (pa_source_output_move_to(o, target, FALSE) < 0)
+@@ -206,17 +234,18 @@ static pa_hook_result_t source_unlink_hook_callback(pa_core *c, pa_source *sourc
+     return PA_HOOK_OK;
+ }
+ 
+-static pa_hook_result_t source_output_move_fail_hook_callback(pa_core *c, pa_source_output *i, void *userdata) {
++static pa_hook_result_t source_output_move_fail_hook_callback(pa_core *c, pa_source_output *i, struct userdata *u) {
+     pa_source *target;
+ 
+     pa_assert(c);
+     pa_assert(i);
++    pa_assert(u);
+ 
+     /* There's no point in doing anything if the core is shut down anyway */
+     if (c->state == PA_CORE_SHUTDOWN)
+         return PA_HOOK_OK;
+ 
+-    if (!(target = find_evacuation_source(c, i, NULL)))
++    if (!(target = find_evacuation_source(u, c, i, NULL)))
+         return PA_HOOK_OK;
+ 
+     if (pa_source_output_finish_move(i, target, FALSE) < 0) {
+@@ -234,6 +263,7 @@ static pa_hook_result_t source_output_move_fail_hook_callback(pa_core *c, pa_sou
+ int pa__init(pa_module*m) {
+     pa_modargs *ma;
+     struct userdata *u;
++    const char *tmp;
+ 
+     pa_assert(m);
+ 
+@@ -242,7 +272,13 @@ int pa__init(pa_module*m) {
+         return -1;
+     }
+ 
+-    m->userdata = u = pa_xnew(struct userdata, 1);
++    m->userdata = u = pa_xnew0(struct userdata, 1);
++
++    if ((tmp = pa_modargs_get_value(ma, "sink_name", NULL)))
++        u->sink_name = pa_xstrdup(tmp);
++
++    if ((tmp = pa_modargs_get_value(ma, "source_name", NULL)))
++        u->source_name = pa_xstrdup(tmp);
+ 
+     /* A little bit later than module-stream-restore, module-intended-roles... */
+     u->sink_unlink_slot = pa_hook_connect(&m->core->hooks[PA_CORE_HOOK_SINK_UNLINK], PA_HOOK_LATE+20, (pa_hook_cb_t) sink_unlink_hook_callback, u);
+@@ -263,6 +299,11 @@ void pa__done(pa_module*m) {
+     if (!(u = m->userdata))
+         return;
+ 
++    if (u->sink_name)
++        pa_xfree(u->sink_name);
++    if (u->source_name)
++        pa_xfree(u->source_name);
++
+     if (u->sink_unlink_slot)
+         pa_hook_slot_free(u->sink_unlink_slot);
+     if (u->source_unlink_slot)
+-- 
+1.8.5.2
+

--- a/rpm/2010-bluetooth-util-Detect-transport-acquire-release-loop.patch
+++ b/rpm/2010-bluetooth-util-Detect-transport-acquire-release-loop.patch
@@ -1,0 +1,60 @@
+From 850fe8f9d7ee570592e88eefb22be7305f2b4821 Mon Sep 17 00:00:00 2001
+From: Timo Honkonen <timo.honkonen@oss.tieto.com>
+Date: Mon, 30 Dec 2013 10:47:49 +0200
+Subject: [PATCH 2010/2010] bluetooth-util: Detect transport acquire-release
+ loop.
+
+---
+ src/modules/bluetooth/bluetooth-util.c | 22 ++++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
+
+diff --git a/src/modules/bluetooth/bluetooth-util.c b/src/modules/bluetooth/bluetooth-util.c
+index 5e4b77b..99fbea5 100644
+--- a/src/modules/bluetooth/bluetooth-util.c
++++ b/src/modules/bluetooth/bluetooth-util.c
+@@ -61,6 +61,8 @@
+     " </interface>"                                                     \
+     "</node>"
+ 
++#define RACE_CONDITION_TIME 1000000  // 1 second
++
+ struct pa_bluetooth_discovery {
+     PA_REFCNT_DECLARE;
+ 
+@@ -506,6 +508,9 @@ static int parse_audio_property(pa_bluetooth_device *d, const char *interface, D
+     DBusMessageIter variant_i;
+     bool is_audio_interface;
+     enum profile p = PROFILE_OFF;
++    pa_usec_t tstamp_now;
++    static pa_usec_t tstamp_prev = 0;
++    DBusMessage *m;
+ 
+     pa_assert(d);
+     pa_assert(interface);
+@@ -537,6 +542,23 @@ static int parse_audio_property(pa_bluetooth_device *d, const char *interface, D
+                 pa_bluetooth_transport_state_t old_state;
+ 
+                 pa_log_debug("Device %s interface %s property 'State' changed to value '%s'", d->path, interface, value);
++                /* Device may change state again (e.g. suspend itself) before previous state change
++                 * message has been parsed here. When this take place sink state in here and bluez
++                 * will be out-of-sync. This may generate endless transport acquire/release loop
++                 * which will be sustained by this module. When we notice this to be ongoing
++                 * message is ignored and current state is queried with GetProperties. */
++                if(pa_streq(interface, "org.bluez.AudioSink") && state==PA_BT_AUDIO_STATE_CONNECTED) {
++                   tstamp_now = pa_rtclock_now();
++                   if (tstamp_prev != 0 && tstamp_now - tstamp_prev < RACE_CONDITION_TIME) {
++                       pa_log_debug("Race condition. Message ignored.");
++                       tstamp_prev = 0;
++                       pa_assert_se(m = dbus_message_new_method_call("org.bluez", d->path, "org.bluez.AudioSink", "GetProperties"));
++                       send_and_add_to_pending(d->discovery, m, get_properties_reply, d);
++
++                       return 0;
++                   }
++                   tstamp_prev = tstamp_now;
++                }
+ 
+                 if (state == PA_BT_AUDIO_STATE_INVALID)
+                     return -1;
+-- 
+1.8.5.2
+

--- a/rpm/pulseaudio.spec
+++ b/rpm/pulseaudio.spec
@@ -14,13 +14,17 @@ URL:        http://pulseaudio.org
 Source0:    http://freedesktop.org/software/pulseaudio/releases/pulseaudio-%{version}.tar.xz
 Source1:    90-pulse.conf
 Source2:    pulseaudio.service
-Patch0:     0001-build-Install-pulsecore-headers.patch
-Patch1:     0002-Use-etc-boardname-to-load-a-hardware-specific-config.patch
-Patch2:     0003-daemon-Disable-automatic-shutdown-by-default.patch
-Patch3:     0004-daemon-Set-default-resampler-to-speex-fixed-2.patch
-Patch4:     0005-bluetooth-Allow-leaving-transport-running-while-sink.patch
-Patch5:     0006-client-Disable-client-autospawn-by-default.patch
-Patch6:     0007-bluetooth-Do-not-lose-transport-pointer-after-gettin.patch
+Patch0:     1001-combine-Fix-crash-in-output-freeing.patch
+Patch1:     2001-build-Install-pulsecore-headers.patch
+Patch2:     2002-Use-etc-boardname-to-load-a-hardware-specific-config.patch
+Patch3:     2003-daemon-Disable-automatic-shutdown-by-default.patch
+Patch4:     2004-daemon-Set-default-resampler-to-speex-fixed-2.patch
+Patch5:     2005-bluetooth-Allow-leaving-transport-running-while-sink.patch
+Patch6:     2006-client-Disable-client-autospawn-by-default.patch
+Patch7:     2007-bluetooth-device-Do-not-lose-transport-pointer-after.patch
+Patch8:     2008-bluetooth-device-Default-to-using-A2DP-profile-initi.patch
+Patch9:     2009-module-rescue-streams-Add-parameters-to-define-targe.patch
+Patch10:    2010-bluetooth-util-Detect-transport-acquire-release-loop.patch
 Requires:   udev
 Requires:   libsbc >= 1.0
 Requires(post): /sbin/ldconfig
@@ -106,27 +110,43 @@ to manage the devices in PulseAudio.
 %prep
 %setup -q -n %{name}-%{version}/pulseaudio
 
-# 0001-build-Install-pulsecore-headers.patch
+# 1001-combine-Fix-crash-in-output-freeing.patch
 %patch0 -p1
-# 0002-Use-etc-boardname-to-load-a-hardware-specific-config.patch
+# 2002-Use-etc-boardname-to-load-a-hardware-specific-config.patch
 %patch1 -p1
-# 0003-daemon-Disable-automatic-shutdown-by-default.patch
+# 2003-daemon-Disable-automatic-shutdown-by-default.patch
 %patch2 -p1
-# 0004-daemon-Set-default-resampler-to-speex-fixed-2.patch
+# 2004-daemon-Set-default-resampler-to-speex-fixed-2.patch
 %patch3 -p1
-# 0005-bluetooth-Allow-leaving-transport-running-while-sink.patch
+# 2005-bluetooth-Allow-leaving-transport-running-while-sink.patch
 %patch4 -p1
-# 0006-client-Disable-client-autospawn-by-default.patch
+# 2006-client-Disable-client-autospawn-by-default.patch
 %patch5 -p1
-# 0007-bluetooth-Do-not-lose-transport-pointer-after-gettin.patch
+# 2007-bluetooth-device-Do-not-lose-transport-pointer-after.patch
 %patch6 -p1
+# 2007-bluetooth-device-Do-not-lose-transport-pointer-after.patch
+%patch7 -p1
+# 2008-bluetooth-device-Default-to-using-A2DP-profile-initi.patch
+%patch8 -p1
+# 2009-module-rescue-streams-Add-parameters-to-define-targe.patch
+%patch9 -p1
+# 2010-bluetooth-util-Detect-transport-acquire-release-loop.patch
+%patch10 -p1
 
 %build
 echo "%{pulseversion}" > .tarball-version
 NOCONFIGURE=1 ./bootstrap.sh
 
+%if %{with X11}
 %configure --disable-static \
-    --disable-neon-opt
+    --disable-neon-opt \
+    --disable-gconf
+%else
+%configure --disable-static \
+    --disable-neon-opt \
+    --disable-gconf \
+    --disable-x11
+%endif
 
 make %{?jobs:-j%jobs}
 


### PR DESCRIPTION
2008-bluetooth-device-Default-to-using-A2DP-profile-initi.patch: Prefer
A2DP profile by default.
2009-module-rescue-streams-Add-parameters-to-define-targe.patch: Add
sink_name and source_name parameters to rescue streams module. When
defined sink or source is found dangling streams are moved to them
instead of default sink/source.
2010-bluetooth-util-Detect-transport-acquire-release-loop.patch: If
bluetooth-device goes into race-issue spamming loop, detect this and try
to recover.
