### PR TITLE
[packaging] Start PulseAudio daemon in forking mode.

### DIFF
--- a/rpm/pulseaudio.service
+++ b/rpm/pulseaudio.service
@@ -4,9 +4,10 @@ After=pre-user-session.target
 Requires=dbus.socket
 
 [Service]
-Type=simple
+Type=forking
+PIDFile=%t/pulse/pid
 EnvironmentFile=-/etc/sysconfig/pulseaudio
-ExecStart=/usr/bin/pulseaudio $CONFIG
+ExecStart=/usr/bin/pulseaudio --start $CONFIG
 Restart=always
 RestartSec=1
 


### PR DESCRIPTION
With simple service type there was chance PulseAudio wasn't properly started up when systemd thought the daemon is up and running. With forking PulseAudio is really up and running when systemd thinks so.
