### PR TITLE
Add patches for starting bluez4 device suspended.

### DIFF
--- a/rpm/1001-core-make-dependencies-compile-for-64bit.patch
+++ b/rpm/1001-core-make-dependencies-compile-for-64bit.patch
@@ -1,7 +1,7 @@
 From 345fb6f1acf1d6b90d10b6c323a6ff7747f6f187 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@jollamobile.com>
 Date: Mon, 6 Jan 2014 11:30:06 +0000
-Subject: [PATCH 1001/1013] core: make dependencies compile for 64bit
+Subject: [PATCH 1001/1015] core: make dependencies compile for 64bit
 
 E.g. pulseaudio-policy-enforcement fails on:
 /usr/include/pulsecore/atomic.h:289:2: error: invalid preprocessing directive #warn
@@ -25,5 +25,5 @@ index 419783d..c8a59f2 100644
  /* Adapted from glibc */
  
 -- 
-1.8.5.2
+1.9.1
 

--- a/rpm/1002-build-Install-pulsecore-headers.patch
+++ b/rpm/1002-build-Install-pulsecore-headers.patch
@@ -1,7 +1,7 @@
 From 281320c6faf042464b14f3dfb9460077d8d7c878 Mon Sep 17 00:00:00 2001
 From: Tanu Kaskinen <tanu.kaskinen@jollamobile.com>
 Date: Wed, 5 Sep 2012 12:23:59 +0300
-Subject: [PATCH 1002/1013] build: Install pulsecore headers.
+Subject: [PATCH 1002/1015] build: Install pulsecore headers.
 
 This is for building out-of-tree modules. Upstream doesn't want to
 support out-of-tree modules, so this patch is not upstreamable.
@@ -198,5 +198,5 @@ index 857fda3..bab318d 100644
  ###################################
  
 -- 
-1.8.5.2
+1.9.1
 

--- a/rpm/1003-daemon-Disable-automatic-shutdown-by-default.patch
+++ b/rpm/1003-daemon-Disable-automatic-shutdown-by-default.patch
@@ -1,7 +1,7 @@
 From 851ac7d1b7c196719ead85b17c83b466954d3f40 Mon Sep 17 00:00:00 2001
 From: Tanu Kaskinen <tanu.kaskinen@jollamobile.com>
 Date: Wed, 10 Oct 2012 11:17:04 +0300
-Subject: [PATCH 1003/1013] daemon: Disable automatic shutdown by default.
+Subject: [PATCH 1003/1015] daemon: Disable automatic shutdown by default.
 
 Mer (or rather Nemo) specific patch, not upstreamable.
 ---
@@ -31,5 +31,5 @@ index 2089058..35c13a4 100644
  
  ; dl-search-path = (depends on architecture)
 -- 
-1.8.5.2
+1.9.1
 

--- a/rpm/1004-daemon-Set-default-resampler-to-speex-fixed-2.patch
+++ b/rpm/1004-daemon-Set-default-resampler-to-speex-fixed-2.patch
@@ -2,7 +2,7 @@ From 8e6391c5453fd250bcec4db72a7ec1da8d8dab7d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Juho=20H=C3=A4m=C3=A4l=C3=A4inen?=
  <juho.hamalainen@tieto.com>
 Date: Thu, 10 Apr 2014 09:41:00 +0300
-Subject: [PATCH 1004/1013] daemon: Set default resampler to speex fixed 2.
+Subject: [PATCH 1004/1015] daemon: Set default resampler to speex fixed 2.
 
 ---
  src/daemon/daemon.conf.in | 18 +++++++++++++++++-
@@ -38,5 +38,5 @@ index 35c13a4..20b1bfd 100644
  ; enable-lfe-remixing = no
  
 -- 
-1.8.5.2
+1.9.1
 

--- a/rpm/1005-module-rescue-streams-Add-parameters-to-define-defau.patch
+++ b/rpm/1005-module-rescue-streams-Add-parameters-to-define-defau.patch
@@ -2,7 +2,7 @@ From 714927eca8fdaf07d142bf6ce96f364de6535683 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Juho=20H=C3=A4m=C3=A4l=C3=A4inen?=
  <juho.hamalainen@tieto.com>
 Date: Thu, 10 Apr 2014 09:44:24 +0300
-Subject: [PATCH 1005/1013] module-rescue-streams: Add parameters to define
+Subject: [PATCH 1005/1015] module-rescue-streams: Add parameters to define
  default targets.
 
 If sink_name or source_name are defined for the module, when streams'
@@ -212,5 +212,5 @@ index 7035a35..e7e96b3 100644
          pa_hook_slot_free(u->sink_unlink_slot);
      if (u->source_unlink_slot)
 -- 
-1.8.5.2
+1.9.1
 

--- a/rpm/1006-client-Disable-client-autospawn-by-default.patch
+++ b/rpm/1006-client-Disable-client-autospawn-by-default.patch
@@ -2,7 +2,7 @@ From 59a1f6ac58db069334e89a0d6633b6c7bc7d9c51 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Juho=20H=C3=A4m=C3=A4l=C3=A4inen?=
  <juho.hamalainen@tieto.com>
 Date: Fri, 4 Oct 2013 12:41:15 +0300
-Subject: [PATCH 1006/1013] client: Disable client autospawn by default.
+Subject: [PATCH 1006/1015] client: Disable client autospawn by default.
 
 Not upstreamable.
 ---
@@ -29,5 +29,5 @@ index 17753b0..86b70b7 100644
  ; extra-arguments = --log-target=syslog
  
 -- 
-1.8.5.2
+1.9.1
 

--- a/rpm/1007-bluez4-device-Allow-leaving-transport-running-while-.patch
+++ b/rpm/1007-bluez4-device-Allow-leaving-transport-running-while-.patch
@@ -2,7 +2,7 @@ From 62ac5075d6ba2f2c03e90c66f45885231e52ba47 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Juho=20H=C3=A4m=C3=A4l=C3=A4inen?=
  <juho.hamalainen@tieto.com>
 Date: Thu, 10 Apr 2014 10:26:42 +0300
-Subject: [PATCH 1007/1013] bluez4-device: Allow leaving transport running
+Subject: [PATCH 1007/1015] bluez4-device: Allow leaving transport running
  while sink and source are suspended.
 
 There are some cases where keeping the SCO transport running even when
@@ -139,5 +139,5 @@ index 83e603f..28ddced 100644
          restore_sco_volume_callbacks(u);
  
 -- 
-1.8.5.2
+1.9.1
 

--- a/rpm/1008-bluez4-device-Do-not-lose-transport-pointer-after-ge.patch
+++ b/rpm/1008-bluez4-device-Do-not-lose-transport-pointer-after-ge.patch
@@ -2,7 +2,7 @@ From 8e812f90473fbc13ec9b7ae7daf61d0ab52014f8 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Juho=20H=C3=A4m=C3=A4l=C3=A4inen?=
  <juho.hamalainen@tieto.com>
 Date: Thu, 10 Apr 2014 10:27:45 +0300
-Subject: [PATCH 1008/1013] bluez4-device: Do not lose transport pointer after
+Subject: [PATCH 1008/1015] bluez4-device: Do not lose transport pointer after
  getting it.
 
 ---
@@ -24,5 +24,5 @@ index 28ddced..12453e1 100644
  
      if (u->sink) {
 -- 
-1.8.5.2
+1.9.1
 

--- a/rpm/1009-bluez4-device-Default-to-using-A2DP-profile-initiall.patch
+++ b/rpm/1009-bluez4-device-Default-to-using-A2DP-profile-initiall.patch
@@ -2,7 +2,7 @@ From b58fef2f1ab4a336fc33d74d17cb432752ead534 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Juho=20H=C3=A4m=C3=A4l=C3=A4inen?=
  <juho.hamalainen@tieto.com>
 Date: Thu, 10 Apr 2014 10:34:06 +0300
-Subject: [PATCH 1009/1013] bluez4-device: Default to using A2DP profile
+Subject: [PATCH 1009/1015] bluez4-device: Default to using A2DP profile
  initially.
 
 By default have A2DP profiles with higher priority than HFP profiles,
@@ -97,5 +97,5 @@ index 12453e1..efd0589 100644
                                device->transports[*d]->state == PA_BLUEZ4_TRANSPORT_STATE_DISCONNECTED)) {
          pa_log_warn("Default profile not connected, selecting off profile");
 -- 
-1.8.5.2
+1.9.1
 

--- a/rpm/1010-bluez4-util-Detect-transport-acquire-release-loop.patch
+++ b/rpm/1010-bluez4-util-Detect-transport-acquire-release-loop.patch
@@ -1,7 +1,7 @@
 From 357814a1c4a1305cbd5d6055ff88c52db613c1c2 Mon Sep 17 00:00:00 2001
 From: Timo Honkonen <timo.honkonen@oss.tieto.com>
 Date: Thu, 10 Apr 2014 10:39:06 +0300
-Subject: [PATCH 1010/1013] bluez4-util: Detect transport acquire-release loop.
+Subject: [PATCH 1010/1015] bluez4-util: Detect transport acquire-release loop.
 
 ---
  src/modules/bluetooth/bluez4-util.c | 23 +++++++++++++++++++++++
@@ -63,5 +63,5 @@ index f047b73..6081fd0 100644
                  if (state == PA_BLUEZ4_AUDIO_STATE_INVALID)
                      return -1;
 -- 
-1.8.5.2
+1.9.1
 

--- a/rpm/1011-daemon-Exit-with-0-on-SIGINT-or-SIGTERM.patch
+++ b/rpm/1011-daemon-Exit-with-0-on-SIGINT-or-SIGTERM.patch
@@ -2,7 +2,7 @@ From 50638b839d72adab6b2ef79f02a6ab077afe9b6e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Juho=20H=C3=A4m=C3=A4l=C3=A4inen?=
  <juho.hamalainen@tieto.com>
 Date: Mon, 9 Jun 2014 14:11:46 +0300
-Subject: [PATCH 1011/1013] daemon: Exit with 0 on SIGINT or SIGTERM.
+Subject: [PATCH 1011/1015] daemon: Exit with 0 on SIGINT or SIGTERM.
 
 ---
  src/daemon/main.c | 2 +-
@@ -22,5 +22,5 @@ index e01371e..a8897bd 100644
      }
  }
 -- 
-1.8.5.2
+1.9.1
 

--- a/rpm/1012-bluez4-device-Fix-assert-when-source-doesn-t-exist-w.patch
+++ b/rpm/1012-bluez4-device-Fix-assert-when-source-doesn-t-exist-w.patch
@@ -2,7 +2,7 @@ From ce456c0c6699109bc9c5ddcfb8a2d2f6ca8a0318 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Juho=20H=C3=A4m=C3=A4l=C3=A4inen?=
  <juho.hamalainen@tieto.com>
 Date: Thu, 17 Jul 2014 09:53:14 +0300
-Subject: [PATCH 1012/1013] bluez4-device: Fix assert when source doesn't exist
+Subject: [PATCH 1012/1015] bluez4-device: Fix assert when source doesn't exist
  when changing properties.
 
 ---
@@ -26,5 +26,5 @@ index efd0589..32392bf 100644
      pa_proplist_sets(p, "bluetooth.nrec", t->nrec ? "1" : "0");
      pa_source_update_proplist(u->source, PA_UPDATE_REPLACE, p);
 -- 
-1.8.5.2
+1.9.1
 

--- a/rpm/1013-core-Use-XDG_RUNTIME_DIR-only-if-owned-by-us.patch
+++ b/rpm/1013-core-Use-XDG_RUNTIME_DIR-only-if-owned-by-us.patch
@@ -2,7 +2,7 @@ From 82957a704331f5fac13a7550e66fd86114ef5458 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Juho=20H=C3=A4m=C3=A4l=C3=A4inen?=
  <juho.hamalainen@tieto.com>
 Date: Fri, 15 Aug 2014 12:30:00 +0300
-Subject: [PATCH 1013/1013] core: Use XDG_RUNTIME_DIR only if owned by us.
+Subject: [PATCH 1013/1015] core: Use XDG_RUNTIME_DIR only if owned by us.
 
 If for some reason XDG_RUNTIME_DIR points to runtime dir not owned by
 our uid, fail. Having wrong XDG_RUNTIME_DIR is especially bad with root,
@@ -31,5 +31,5 @@ index 0d9e354..83cd40d 100644
  
          if (pa_make_secure_dir(k, m, (uid_t) -1, (gid_t) -1, true) < 0) {
 -- 
-1.8.5.2
+1.9.1
 

--- a/rpm/1014-bluez-device-Check-for-transport-suspend-on-profile-.patch
+++ b/rpm/1014-bluez-device-Check-for-transport-suspend-on-profile-.patch
@@ -1,0 +1,77 @@
+From ecf235968d7e522a292aab1d7988e061793f9571 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Juho=20H=C3=A4m=C3=A4l=C3=A4inen?=
+ <juho.hamalainen@tieto.com>
+Date: Mon, 30 Mar 2015 12:27:41 +0300
+Subject: [PATCH 1014/1015] bluez-device: Check for transport suspend on
+ profile change.
+
+---
+ src/modules/bluetooth/module-bluez4-device.c | 27 ++++++++++++++++++++-------
+ 1 file changed, 20 insertions(+), 7 deletions(-)
+
+diff --git a/src/modules/bluetooth/module-bluez4-device.c b/src/modules/bluetooth/module-bluez4-device.c
+index 32392bf..61daa16 100644
+--- a/src/modules/bluetooth/module-bluez4-device.c
++++ b/src/modules/bluetooth/module-bluez4-device.c
+@@ -423,31 +423,42 @@ static int check_proplist(struct userdata *u) {
+  * Also, if the sink&source are suspended when sco-sink suspend.transport value changes to true,
+  * bring sco transport up. When suspend.transport value changes to false while sink&source are suspended,
+  * tear down the transport. */
+-static pa_hook_result_t update_allow_release_cb(pa_core *c, pa_sink *s, struct userdata *u) {
++static void update_allow_release(struct userdata *u) {
+     pa_assert(u);
+-    pa_assert(s);
+ 
+-    if (!u->hsp.sco_sink || u->hsp.sco_sink != s)
+-        return PA_HOOK_OK;
++    if (!u->hsp.sco_sink)
++        return;
+ 
+     if (check_proplist(u) < 0)
+-        return PA_HOOK_OK;
++        return;
+ 
+     if (!USE_SCO_OVER_PCM(u)) {
+         pa_log_debug("SCO sink not available.");
+-        return PA_HOOK_OK;
++        return;
+     }
+ 
+     if (!PA_SINK_IS_OPENED(pa_sink_get_state(u->hsp.sco_sink)) &&
+         !PA_SOURCE_IS_OPENED(pa_source_get_state(u->hsp.sco_source))) {
+ 
+         /* Clear all suspend bits, effectively resuming SCO sink for a while. */
+-        pa_sink_suspend(s, FALSE, PA_SUSPEND_ALL);
++        pa_sink_suspend(u->hsp.sco_sink, FALSE, PA_SUSPEND_ALL);
+     }
+ 
+     return PA_HOOK_OK;
+ }
+ 
++static pa_hook_result_t update_allow_release_cb(pa_core *c, pa_sink *s, struct userdata *u) {
++    pa_assert(u);
++    pa_assert(s);
++
++    if (!u->hsp.sco_sink || u->hsp.sco_sink != s)
++        return PA_HOOK_OK;
++
++    update_allow_release(u);
++
++    return PA_HOOK_OK;
++}
++
+ /* Run from IO thread */
+ static int sink_process_msg(pa_msgobject *o, int code, void *data, int64_t offset, pa_memchunk *chunk) {
+     struct userdata *u = PA_SINK(o)->userdata;
+@@ -2131,6 +2142,8 @@ static int card_set_profile(pa_card *c, pa_card_profile *new_profile) {
+         if (start_thread(u) < 0)
+             goto off;
+ 
++    update_allow_release(u);
++
+     return 0;
+ 
+ off:
+-- 
+1.9.1
+

--- a/rpm/1015-bluez4-device-Don-t-acquire-transport-when-connectin.patch
+++ b/rpm/1015-bluez4-device-Don-t-acquire-transport-when-connectin.patch
@@ -1,0 +1,237 @@
+From 68678a5633c18fe3401c0cad68f8c9262f2faa9f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Juho=20H=C3=A4m=C3=A4l=C3=A4inen?=
+ <juho.hamalainen@tieto.com>
+Date: Mon, 30 Mar 2015 11:28:09 +0300
+Subject: [PATCH 1015/1015] bluez4-device: Don't acquire transport when
+ connecting device.
+
+When creating module-bluez4-device do not acquire transport but start
+the sink and source in suspended state. Then acquire transport normally
+upon first and subsequent use.
+
+Without this change PTS test A2DP TC_SRC_AS_BV_01_I fails.
+
+From bug JB#27276:
+
+PTS takes the AVDTP streaming start for the silence as a sign that IUT
+proceeds with the test case and after idle timeout stream suspend comes
+along, PTS disconnects the audio connection, so trying to stream
+something from the media player after that doesn't have any effect on
+the test case.
+
+Technically speaking the test case does work, but since there's no
+audible sound to check streaming takes place the qualification engineer
+would fail the verification.
+---
+ src/modules/bluetooth/module-bluez4-device.c | 82 +++++++++++++++-------------
+ 1 file changed, 43 insertions(+), 39 deletions(-)
+
+diff --git a/src/modules/bluetooth/module-bluez4-device.c b/src/modules/bluetooth/module-bluez4-device.c
+index 61daa16..361b3ae 100644
+--- a/src/modules/bluetooth/module-bluez4-device.c
++++ b/src/modules/bluetooth/module-bluez4-device.c
+@@ -141,6 +141,7 @@ struct userdata {
+     char *path;
+     pa_bluez4_transport *transport;
+     bool transport_acquired;
++    bool transport_configured;
+     pa_hook_slot *discovery_slot;
+     pa_hook_slot *sink_state_changed_slot;
+     pa_hook_slot *source_state_changed_slot;
+@@ -211,6 +212,9 @@ enum {
+ #define BLUETOOTH_PREFER_HSP "bluetooth.prefer.hsp"
+ 
+ static int init_profile(struct userdata *u);
++static int bt_transport_setup(struct userdata *u);
++static int bt_transport_acquire(struct userdata *u, bool optional);
++static void bt_transport_config(struct userdata *u);
+ 
+ /* from IO thread */
+ static void a2dp_set_bitpool(struct userdata *u, uint8_t bitpool) {
+@@ -363,13 +367,10 @@ static void bt_transport_release(struct userdata *u) {
+     teardown_stream(u);
+ }
+ 
+-static int bt_transport_acquire(struct userdata *u, bool optional) {
++static int transport_acquire(struct userdata *u, bool optional) {
+     pa_assert(u->transport);
+ 
+-    if (u->transport_acquired)
+-        return 0;
+-
+-    pa_log_debug("Acquiring transport %s", u->transport->path);
++    pa_log_debug("Acquiring transport %s%s", u->transport->path, optional ? " (optional)" : "");
+ 
+     u->stream_fd = pa_bluez4_transport_acquire(u->transport, optional, &u->read_link_mtu, &u->write_link_mtu);
+     if (u->stream_fd < 0) {
+@@ -497,8 +498,10 @@ static int sink_process_msg(pa_msgobject *o, int code, void *data, int64_t offse
+                     if (!u->source || !PA_SOURCE_IS_OPENED(u->source->thread_info.state)) {
+                         if (bt_transport_acquire(u, false) < 0)
+                             failed = true;
+-                        else
++                        else {
++                            bt_transport_config(u);
+                             setup_stream(u);
++                        }
+                     }
+                     break;
+ 
+@@ -574,8 +577,10 @@ static int source_process_msg(pa_msgobject *o, int code, void *data, int64_t off
+                     if (!u->sink || !PA_SINK_IS_OPENED(u->sink->thread_info.state)) {
+                         if (bt_transport_acquire(u, false) < 0)
+                             failed = true;
+-                        else
++                        else {
++                            bt_transport_config(u);
+                             setup_stream(u);
++                        }
+                     }
+                     /* We don't resume the smoother here. Instead we
+                      * wait until the first packet arrives */
+@@ -1359,6 +1364,7 @@ static void handle_transport_state_change(struct userdata *u, struct pa_bluez4_t
+ 
+     if (acquire)
+         if (bt_transport_acquire(u, true) >= 0) {
++            bt_transport_config(u);
+             if (u->source) {
+                 pa_log_debug("Resuming source %s, because the bluetooth audio state changed to 'playing'.", u->source->name);
+                 pa_source_suspend(u->source, false, PA_SUSPEND_IDLE|PA_SUSPEND_USER);
+@@ -1491,6 +1497,8 @@ static int sco_over_pcm_state_update(struct userdata *u, bool changed) {
+         if (bt_transport_acquire(u, false) < 0)
+             return -1;
+ 
++        bt_transport_config(u);
++
+         setup_stream(u);
+ 
+         return 0;
+@@ -1651,6 +1659,7 @@ static int add_sink(struct userdata *u) {
+         data.card = u->card;
+         data.name = get_name("sink", u->modargs, u->address, &b);
+         data.namereg_fail = b;
++        data.suspend_cause = PA_SUSPEND_IDLE;
+ 
+         if (pa_modargs_get_proplist(u->modargs, "sink_properties", data.proplist, PA_UPDATE_REPLACE) < 0) {
+             pa_log("Invalid properties");
+@@ -1659,19 +1668,8 @@ static int add_sink(struct userdata *u) {
+         }
+         connect_ports(u, &data, PA_DIRECTION_OUTPUT);
+ 
+-        if (!u->transport_acquired)
+-            switch (u->profile) {
+-                case PA_BLUEZ4_PROFILE_A2DP:
+-                case PA_BLUEZ4_PROFILE_HSP:
+-                    pa_assert_not_reached(); /* Profile switch should have failed */
+-                    break;
+-                case PA_BLUEZ4_PROFILE_HFGW:
+-                    data.suspend_cause = PA_SUSPEND_USER;
+-                    break;
+-                case PA_BLUEZ4_PROFILE_A2DP_SOURCE:
+-                case PA_BLUEZ4_PROFILE_OFF:
+-                    pa_assert_not_reached();
+-            }
++        if (!u->transport_acquired && u->profile == PA_BLUEZ4_PROFILE_HFGW)
++            data.suspend_cause |= PA_SUSPEND_USER;
+ 
+         u->sink = pa_sink_new(u->core, &data, PA_SINK_HARDWARE|PA_SINK_LATENCY);
+         pa_sink_new_data_done(&data);
+@@ -1722,6 +1720,7 @@ static int add_source(struct userdata *u) {
+         data.card = u->card;
+         data.name = get_name("source", u->modargs, u->address, &b);
+         data.namereg_fail = b;
++        data.suspend_cause = PA_SUSPEND_IDLE;
+ 
+         if (pa_modargs_get_proplist(u->modargs, "source_properties", data.proplist, PA_UPDATE_REPLACE) < 0) {
+             pa_log("Invalid properties");
+@@ -1731,19 +1730,8 @@ static int add_source(struct userdata *u) {
+ 
+         connect_ports(u, &data, PA_DIRECTION_INPUT);
+ 
+-        if (!u->transport_acquired)
+-            switch (u->profile) {
+-                case PA_BLUEZ4_PROFILE_HSP:
+-                    pa_assert_not_reached(); /* Profile switch should have failed */
+-                    break;
+-                case PA_BLUEZ4_PROFILE_A2DP_SOURCE:
+-                case PA_BLUEZ4_PROFILE_HFGW:
+-                    data.suspend_cause = PA_SUSPEND_USER;
+-                    break;
+-                case PA_BLUEZ4_PROFILE_A2DP:
+-                case PA_BLUEZ4_PROFILE_OFF:
+-                    pa_assert_not_reached();
+-            }
++        if (!u->transport_acquired && u->profile == PA_BLUEZ4_PROFILE_HFGW)
++            data.suspend_cause |= PA_SUSPEND_USER;
+ 
+         u->source = pa_source_new(u->core, &data, PA_SOURCE_HARDWARE|PA_SOURCE_LATENCY);
+         pa_source_new_data_done(&data);
+@@ -1887,12 +1875,17 @@ static void bt_transport_config_a2dp(struct userdata *u) {
+ }
+ 
+ static void bt_transport_config(struct userdata *u) {
++    if (u->transport_configured)
++        return;
++
+     if (u->profile == PA_BLUEZ4_PROFILE_HSP || u->profile == PA_BLUEZ4_PROFILE_HFGW) {
+         u->sample_spec.format = PA_SAMPLE_S16LE;
+         u->sample_spec.channels = 1;
+         u->sample_spec.rate = 8000;
+     } else
+         bt_transport_config_a2dp(u);
++
++    u->transport_configured = true;
+ }
+ 
+ /* Run from main thread */
+@@ -1910,7 +1903,7 @@ static pa_hook_result_t transport_state_changed_cb(pa_bluez4_discovery *y, pa_bl
+ }
+ 
+ /* Run from main thread */
+-static int setup_transport(struct userdata *u) {
++static int bt_transport_setup(struct userdata *u) {
+     pa_bluez4_transport *t;
+ 
+     pa_assert(u);
+@@ -1926,13 +1919,22 @@ static int setup_transport(struct userdata *u) {
+ 
+     u->transport = t;
+ 
++    return 0;
++}
++
++static int bt_transport_acquire(struct userdata *u, bool optional) {
++    pa_assert(u);
++
++    if (u->transport_acquired) {
++        pa_log_debug("Transport already acquired");
++        return 0;
++    }
++
+     if (u->profile == PA_BLUEZ4_PROFILE_A2DP_SOURCE || u->profile == PA_BLUEZ4_PROFILE_HFGW)
+-        bt_transport_acquire(u, true); /* In case of error, the sink/sources will be created suspended */
+-    else if (bt_transport_acquire(u, false) < 0)
++        transport_acquire(u, optional); /* In case of error, the sink/sources will be created suspended */
++    else if (transport_acquire(u, optional) < 0)
+         return -1; /* We need to fail here until the interactions with module-suspend-on-idle and alike get improved */
+ 
+-    bt_transport_config(u);
+-
+     return 0;
+ }
+ 
+@@ -1942,9 +1944,11 @@ static int init_profile(struct userdata *u) {
+     pa_assert(u);
+     pa_assert(u->profile != PA_BLUEZ4_PROFILE_OFF);
+ 
+-    if (setup_transport(u) < 0)
++    if (bt_transport_setup(u) < 0)
+         return -1;
+ 
++    u->transport_configured = false;
++
+     pa_assert(u->transport);
+ 
+     if (u->profile == PA_BLUEZ4_PROFILE_A2DP ||
+-- 
+1.9.1
+

--- a/rpm/pulseaudio.spec
+++ b/rpm/pulseaudio.spec
@@ -27,7 +27,9 @@ Patch9:     1010-bluez4-util-Detect-transport-acquire-release-loop.patch
 Patch10:    1011-daemon-Exit-with-0-on-SIGINT-or-SIGTERM.patch
 Patch11:    1012-bluez4-device-Fix-assert-when-source-doesn-t-exist-w.patch
 Patch12:    1013-core-Use-XDG_RUNTIME_DIR-only-if-owned-by-us.patch
-Patch13:    2001-dbus-Use-correct-initialization-for-source-ports-has.patch
+Patch13:    1014-bluez-device-Check-for-transport-suspend-on-profile-.patch
+Patch14:    1015-bluez4-device-Don-t-acquire-transport-when-connectin.patch
+Patch15:    2001-dbus-Use-correct-initialization-for-source-ports-has.patch
 Requires:   udev
 Requires:   libsbc >= 1.0
 Requires(post): /sbin/ldconfig
@@ -139,8 +141,12 @@ to manage the devices in PulseAudio.
 %patch11 -p1
 # 1013-core-Use-XDG_RUNTIME_DIR-only-if-owned-by-us.patch
 %patch12 -p1
-# 2001-dbus-Use-correct-initialization-for-source-ports-has.patch
+# 1014-bluez-device-Check-for-transport-suspend-on-profile-.patch
 %patch13 -p1
+# 1015-bluez4-device-Don-t-acquire-transport-when-connectin.patch
+%patch14 -p1
+# 2001-dbus-Use-correct-initialization-for-source-ports-has.patch
+%patch15 -p1
 
 %build
 echo "%{pulseversion}" > .tarball-version

--- a/rpm/pulseaudio.spec
+++ b/rpm/pulseaudio.spec
@@ -311,7 +311,12 @@ ln -s ../pulseaudio.service %{buildroot}/usr/lib/systemd/user/user-session.targe
 %{_libdir}/pulse-%{pulseversion}/modules/module-volume-restore.so
 %{_libdir}/pulse-%{pulseversion}/modules/module-remap-source.so
 %{_libdir}/pulse-%{pulseversion}/modules/module-role-ducking.so
+%dir %{_libdir}/pulseaudio
 %{_libdir}/pulseaudio/*.so
+%dir %{_datadir}/pulseaudio
+%dir %{_datadir}/pulseaudio/alsa-mixer
+%dir %{_datadir}/pulseaudio/alsa-mixer/paths
+%dir %{_datadir}/pulseaudio/alsa-mixer/profile-sets
 %{_datadir}/pulseaudio/alsa-mixer/paths/*.conf
 %{_datadir}/pulseaudio/alsa-mixer/paths/*.common
 %{_datadir}/pulseaudio/alsa-mixer/profile-sets/*.conf


### PR DESCRIPTION
bluez-device-Check-for-transport-suspend-on-profile-.patch:
Make sure SCO transport suspending always follows sink proplist state.

1015-bluez4-device-Don-t-acquire-transport-when-connectin.patch:
Don't acquire transport when creating bluez4-device, but whenever the
sinks or sources are used for the first time.